### PR TITLE
fix: vpc version in supporting resources

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -1,0 +1,14 @@
+name: auto-merge
+
+on:
+  pull_request:
+    types:
+    - opened
+    - reopened
+
+jobs:
+  auto-merge:
+    uses: boldlink/terraform-module-support/.github/workflows/auto-merge.yaml@main
+    secrets:
+      AUTOMATION_TOKEN: ${{ secrets.AUTOMATION_TOKEN }}
+      SLACK_WEBHOOK : ${{secrets.SLACK_WEBHOOK}}

--- a/.github/workflows/config/prl-config.yaml
+++ b/.github/workflows/config/prl-config.yaml
@@ -1,3 +1,3 @@
 major: ['release/*', 'releases/*']
-minor: ['feature/*', 'features/*' ]
+minor: ['feat*/*', 'feature/*', 'features/*' ]
 patch: ['fix/*', 'fixes/*', 'hotfix/*', 'hotfixes/*', chore/*, 'chores/*']

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix: Version lock
 - Added: Efs module example
 
-[Unreleased]: https://github.com/boldlink/terraform-aws-efs/compare/1.1.2...HEAD
+[Unreleased]: https://github.com/boldlink/terraform-aws-efs/compare/1.1.3...HEAD
 
+[1.1.3]: https://github.com/boldlink/terraform-aws-efs/releases/tag/1.1.3
 [1.1.2]: https://github.com/boldlink/terraform-aws-efs/releases/tag/1.1.2
 [1.1.1]: https://github.com/boldlink/terraform-aws-efs/releases/tag/1.1.1
 [1.1.0]: https://github.com/boldlink/terraform-aws-efs/releases/tag/1.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat: Add access point support
 - feat: Add replication support
 - feat: Add backup policy support
+- fix: CKV_TF_1: "Ensure Terraform module sources use a commit hash"
+
+## [1.1.3] - 2023-08-14
+- fix: VPC version used in supporting resources. This is to fix pre-commit errors for deprecated outputs
 
 ## [1.1.2] - 2023-03-02
 ### Description

--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ tfmoduleclean:
 		cd $(SUPPORTING_PATH) ;\
 		rm -rf .terraform* ;\
 	fi
-	@for folder in $(MODULEDIRS) ; do \
+	@for folder in $(SUBDIRS) ; do \
 		echo "=====================================================================================================" ;\
 		echo "[info]: Cleaning $$folder terraform files" ;\
 		echo "=====================================================================================================" ;\

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ module "complete_efs" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.63.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.12.0 |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Build Status](https://github.com/boldlink/terraform-aws-efs/actions/workflows/pr-labeler.yaml/badge.svg)](https://github.com/boldlink/terraform-aws-efs/actions)
 [![Build Status](https://github.com/boldlink/terraform-aws-efs/actions/workflows/module-examples-tests.yaml/badge.svg)](https://github.com/boldlink/terraform-aws-efs/actions)
 [![Build Status](https://github.com/boldlink/terraform-aws-efs/actions/workflows/checkov.yaml/badge.svg)](https://github.com/boldlink/terraform-aws-efs/actions)
+[![Build Status](https://github.com/boldlink/terraform-aws-efs/actions/workflows/auto-merge.yaml/badge.svg)](https://github.com/boldlink/terraform-aws-efs/actions)
 [![Build Status](https://github.com/boldlink/terraform-aws-efs/actions/workflows/auto-badge.yaml/badge.svg)](https://github.com/boldlink/terraform-aws-efs/actions)
 
 [<img src="https://avatars.githubusercontent.com/u/25388280?s=200&v=4" width="96"/>](https://boldlink.io)

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -25,7 +25,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.52.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.12.0 |
 
 ## Modules
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -6,6 +6,7 @@
 [![Build Status](https://github.com/boldlink/terraform-aws-efs/actions/workflows/pr-labeler.yaml/badge.svg)](https://github.com/boldlink/terraform-aws-efs/actions)
 [![Build Status](https://github.com/boldlink/terraform-aws-efs/actions/workflows/module-examples-tests.yaml/badge.svg)](https://github.com/boldlink/terraform-aws-efs/actions)
 [![Build Status](https://github.com/boldlink/terraform-aws-efs/actions/workflows/checkov.yaml/badge.svg)](https://github.com/boldlink/terraform-aws-efs/actions)
+[![Build Status](https://github.com/boldlink/terraform-aws-efs/actions/workflows/auto-merge.yaml/badge.svg)](https://github.com/boldlink/terraform-aws-efs/actions)
 [![Build Status](https://github.com/boldlink/terraform-aws-efs/actions/workflows/auto-badge.yaml/badge.svg)](https://github.com/boldlink/terraform-aws-efs/actions)
 
 [<img src="https://avatars.githubusercontent.com/u/25388280?s=200&v=4" width="96"/>](https://boldlink.io)

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -25,7 +25,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.63.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.52.0 |
 
 ## Modules
 

--- a/examples/complete/data.tf
+++ b/examples/complete/data.tf
@@ -20,5 +20,5 @@ data "aws_subnet" "public" {
 
 data "aws_security_group" "default" {
   vpc_id = data.aws_vpc.supporting.id
-  name = "default"
+  name   = "default"
 }

--- a/examples/complete/data.tf
+++ b/examples/complete/data.tf
@@ -20,4 +20,5 @@ data "aws_subnet" "public" {
 
 data "aws_security_group" "default" {
   vpc_id = data.aws_vpc.supporting.id
+  name = "default"
 }

--- a/examples/minimum/README.md
+++ b/examples/minimum/README.md
@@ -6,6 +6,7 @@
 [![Build Status](https://github.com/boldlink/terraform-aws-efs/actions/workflows/pr-labeler.yaml/badge.svg)](https://github.com/boldlink/terraform-aws-efs/actions)
 [![Build Status](https://github.com/boldlink/terraform-aws-efs/actions/workflows/module-examples-tests.yaml/badge.svg)](https://github.com/boldlink/terraform-aws-efs/actions)
 [![Build Status](https://github.com/boldlink/terraform-aws-efs/actions/workflows/checkov.yaml/badge.svg)](https://github.com/boldlink/terraform-aws-efs/actions)
+[![Build Status](https://github.com/boldlink/terraform-aws-efs/actions/workflows/auto-merge.yaml/badge.svg)](https://github.com/boldlink/terraform-aws-efs/actions)
 [![Build Status](https://github.com/boldlink/terraform-aws-efs/actions/workflows/auto-badge.yaml/badge.svg)](https://github.com/boldlink/terraform-aws-efs/actions)
 
 [<img src="https://avatars.githubusercontent.com/u/25388280?s=200&v=4" width="96"/>](https://boldlink.io)

--- a/tests/supportingResources/README.md
+++ b/tests/supportingResources/README.md
@@ -34,7 +34,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | boldlink/vpc/aws | 3.0.2 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | boldlink/vpc/aws | 3.0.4 |
 
 ## Resources
 
@@ -45,7 +45,12 @@ No resources.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_cidr_block"></a> [cidr\_block](#input\_cidr\_block) | CIDR block of the VPC | `string` | `"10.1.0.0/16"` | no |
+| <a name="input_enable_dns_hostnames"></a> [enable\_dns\_hostnames](#input\_enable\_dns\_hostnames) | Whether to enable dns hostnames | `bool` | `true` | no |
+| <a name="input_enable_dns_support"></a> [enable\_dns\_support](#input\_enable\_dns\_support) | Whether to enable dns support for the vpc | `bool` | `true` | no |
+| <a name="input_enable_public_subnets"></a> [enable\_public\_subnets](#input\_enable\_public\_subnets) | Whether to enable public subnets | `bool` | `true` | no |
+| <a name="input_map_public_ip_on_launch"></a> [map\_public\_ip\_on\_launch](#input\_map\_public\_ip\_on\_launch) | Whether assign public IPs by default to instances launched on subnet | `bool` | `true` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of the stack | `string` | `"terraform-aws-efs"` | no |
+| <a name="input_nat"></a> [nat](#input\_nat) | Choose `single` or `multi` for NATs | `string` | `"single"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | The resource tags to be applied | `map(string)` | <pre>{<br>  "Department": "DevOps",<br>  "Environment": "example",<br>  "LayerId": "Example",<br>  "LayerName": "Example",<br>  "Owner": "Boldlink",<br>  "Project": "Examples",<br>  "user::CostCenter": "terraform-registry"<br>}</pre> | no |
 
 ## Outputs

--- a/tests/supportingResources/README.md
+++ b/tests/supportingResources/README.md
@@ -6,6 +6,7 @@
 [![Build Status](https://github.com/boldlink/terraform-aws-efs/actions/workflows/pr-labeler.yaml/badge.svg)](https://github.com/boldlink/terraform-aws-efs/actions)
 [![Build Status](https://github.com/boldlink/terraform-aws-efs/actions/workflows/module-examples-tests.yaml/badge.svg)](https://github.com/boldlink/terraform-aws-efs/actions)
 [![Build Status](https://github.com/boldlink/terraform-aws-efs/actions/workflows/checkov.yaml/badge.svg)](https://github.com/boldlink/terraform-aws-efs/actions)
+[![Build Status](https://github.com/boldlink/terraform-aws-efs/actions/workflows/auto-merge.yaml/badge.svg)](https://github.com/boldlink/terraform-aws-efs/actions)
 [![Build Status](https://github.com/boldlink/terraform-aws-efs/actions/workflows/auto-badge.yaml/badge.svg)](https://github.com/boldlink/terraform-aws-efs/actions)
 
 [<img src="https://avatars.githubusercontent.com/u/25388280?s=200&v=4" width="96"/>](https://boldlink.io)

--- a/tests/supportingResources/main.tf
+++ b/tests/supportingResources/main.tf
@@ -1,18 +1,19 @@
 module "vpc" {
+  #checkov:skip=CKV_TF_1
   source                = "boldlink/vpc/aws"
-  version               = "3.0.2"
+  version               = "3.0.4"
   name                  = var.name
   cidr_block            = var.cidr_block
-  enable_dns_support    = true
-  enable_dns_hostnames  = true
-  enable_public_subnets = true
+  enable_dns_support    = var.enable_dns_support
+  enable_dns_hostnames  = var.enable_dns_hostnames
+  enable_public_subnets = var.enable_public_subnets
   tags                  = var.tags
 
   public_subnets = {
     public = {
       cidrs                   = local.public_subnets
-      map_public_ip_on_launch = true
-      nat                     = "single"
+      map_public_ip_on_launch = var.map_public_ip_on_launch
+      nat                     = var.nat
     }
   }
 }

--- a/tests/supportingResources/variables.tf
+++ b/tests/supportingResources/variables.tf
@@ -23,3 +23,33 @@ variable "cidr_block" {
   description = "CIDR block of the VPC"
   default     = "10.1.0.0/16"
 }
+
+variable "enable_dns_hostnames" {
+  type        = bool
+  description = "Whether to enable dns hostnames"
+  default     = true
+}
+
+variable "enable_dns_support" {
+  type        = bool
+  description = "Whether to enable dns support for the vpc"
+  default     = true
+}
+
+variable "enable_public_subnets" {
+  type        = bool
+  description = "Whether to enable public subnets"
+  default     = true
+}
+
+variable "map_public_ip_on_launch" {
+  type        = bool
+  description = "Whether assign public IPs by default to instances launched on subnet"
+  default     = true
+}
+
+variable "nat" {
+  type        = string
+  description = "Choose `single` or `multi` for NATs"
+  default     = "single"
+}


### PR DESCRIPTION
# Description

This PR fixes the VPC version used in supporting resources

## Features/Fixes/Patches/Changes list:

Please check the [CHANGELOG.md](https://github.com/boldlink/terraform-aws-efs/blob/fix/vpc-version/CHANGELOG.md#113---2023-08-14)

## Checklists:
<!-- You can erase any parts of this template not applicable to your Pull Request. -->
### PR Owners Checklist:
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you checked there aren't open [Pull Requests](../../../pulls) of upstream or parallel code that will cause conflicts?
* [x] Have you updated the `CHANGELOG.md`?
* [x] Have you updated the `README.md`(s)?
* [x] OWNER: Does your submission pass?
    * [ ] Pre-commit (attach logs/print screen to this PR)
    * [ ] Checkov/terrascan (attach logs/print screen to this PR)
    * [ ] Terraform resources examples build/destroy successfully with Terraform 0.14.11 minimum?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] First PR? Have you deleted `## How to use this template...` from the root `.README.md`?

### PR Reviewers Checklists?
* [ ] Are all your comments/changes resolved?
* [ ] Are you happy with the OWNER checklists and additional information provided?
* [ ] Does your review tests pass?
    * [ ] Terraform resources examples build/destroy successfully with Terraform 0.14.11 minimum?
